### PR TITLE
Language bindings → Binding generators

### DIFF
--- a/capi_problems.rst
+++ b/capi_problems.rst
@@ -165,7 +165,7 @@ faster or the safer and more stable version of the API.
 **Binding generators**
 
 Libraries that create bindings between Python and other object models,
-paradigms or languages other than C, such as
+paradigms or languages, such as
 `pybind11 <https://pybind11.readthedocs.io/en/stable/>`__ for C++11,
 `PyO3 <https://github.com/PyO3/pyo3>`__ for Rust,
 `PySide <https://pypi.org/project/PySide/>`__ for Qt,

--- a/capi_problems.rst
+++ b/capi_problems.rst
@@ -162,14 +162,17 @@ and lower stability guarantees. Then the developers and users of
 these tools can choose whether to generate code that uses the
 faster or the safer and more stable version of the API.
 
-**Language bindings**
+**Binding generators**
 
-Libraries that create bindings between Python and code written in
-languages other than C, such as
+Libraries that create bindings between Python and other object models,
+paradigms or languages other than C, such as
 `pybind11 <https://pybind11.readthedocs.io/en/stable/>`__ for C++11,
 `PyO3 <https://github.com/PyO3/pyo3>`__ for Rust,
-`PySide <https://pypi.org/project/PySide/>`__ for Qt, and
-`Pygolo <https://gitlab.com/pygolo/py>`__ for Go.
+`PySide <https://pypi.org/project/PySide/>`__ for Qt,
+`PyGObject <https://pygobject.readthedocs.io/en/latest/>`__ for GTK,
+`Pygolo <https://gitlab.com/pygolo/py>`__ for Go,
+`PyJNIus <https://github.com/kivy/pyjnius/>`__ for Java, or
+`SWIG <https://swig.org/>`__ for C/C++.
 
 They need to:
 


### PR DESCRIPTION
I've thought a bit about the term we use here, but didn't get to updating it in the Wiki.

---

The fact that most of these are for other languages is secondary; the main thing they're bridging to is a different object model. For example, GTK (GObject) is written in C, and the binding generator has the same kind of requirements as the others.

These are *generators*. Some simpler C projects have hand-rolled Python bindings, but those ast as normal extensions.